### PR TITLE
chore: prevent too many release comments hitting github rate limits

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -3,6 +3,13 @@
   "plugins": [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
-    "@semantic-release/github"
+    [
+      "@semantic-release/github",
+      {
+        "successComment": false,
+        "failComment": false,
+        "failTitle": false
+      }
+    ]
   ]
 }


### PR DESCRIPTION
# chore: prevent too many release comments hitting github rate limits

---

# Pull request stack

- 👉🏻 **[#524](https://github.com/mikavilpas/mika-renovate/pull/524)** | chore: prevent too many release comments hitting github rate limits 👈🏻