### PR TITLE
chore: run zizmor autofixes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,6 @@ jobs:
         if: steps.changesets.outputs.pullRequestNumber
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          STEPS_CHANGESETS_OUTPUTS_PULLREQUESTNUMBER: ${{ steps.changesets.outputs.pullRequestNumber }}
         run: >
-          gh pr merge "${{ steps.changesets.outputs.pullRequestNumber }}" --auto --squash --repo "${{ github.repository
-          }}"
+          gh pr merge "${STEPS_CHANGESETS_OUTPUTS_PULLREQUESTNUMBER}" --auto --squash --repo "${{ github.repository }}"

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,3 @@
 pnpm-lock.yaml
 .changeset/
+**/CHANGELOG.md


### PR DESCRIPTION
# chore: exempt all CHANGELOG.md files from oxfmt formatting

# chore: run zizmor autofixes

```sh
info[template-injection]: code injection via template expansion
  --> ./.github/workflows/release.yml:64:28
   |
63 |         run: >
   |         --- this run block
64 |           gh pr merge "${{ steps.changesets.outputs.pullRequestNumber }}" --auto --squash --repo "${{ github.repository
   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ may expand into attacker-controllable code
   |
   = note: audit confidence → Low
   = note: this finding has an auto-fix
```

---

# Pull request stack

- 👉🏻 https://github.com/mikavilpas/mika-config/pull/616 👈🏻