### PR TITLE
ci: reimplement releases for the root package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,3 +64,28 @@ jobs:
           STEPS_CHANGESETS_OUTPUTS_PULLREQUESTNUMBER: ${{ steps.changesets.outputs.pullRequestNumber }}
         run: >
           gh pr merge "${STEPS_CHANGESETS_OUTPUTS_PULLREQUESTNUMBER}" --auto --squash --repo "${{ github.repository }}"
+
+      - name: Tag and release the private root package
+        # The root @mikavilpas/mika-config is private, so `changeset publish`
+        # does not touch it beyond bumping the package.json version. Craete a
+        # tag and github release so that I can track all the changes manually
+        # in the same github releases view.
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          version="$(jq --raw-output .version package.json)"
+          tag="v${version}"
+          if git rev-parse --verify --quiet "refs/tags/${tag}" >/dev/null; then
+            echo "Tag ${tag} already exists, nothing to release."
+            exit 0
+          fi
+          cliff_version="$(yq --input-format toml --output-format yaml '.tools.git-cliff' mise.toml)"
+          notes="$(npx --yes "git-cliff@${cliff_version}" --tag-pattern '^v[0-9]' --unreleased --tag "${tag}" --strip all)"
+          git tag "${tag}"
+          git push origin "${tag}"
+          if [ -z "$(printf '%s' "${notes}" | tr -d '[:space:]')" ]; then
+            gh release create "${tag}" --title "${tag}" --generate-notes
+          else
+            printf '%s\n' "${notes}" | gh release create "${tag}" --title "${tag}" --notes-file -
+          fi

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,5 @@
+[tools]
+# renovate bumps this version automatically. git-cliff stays out of the regular
+# pnpm i + cache installation but is still available as a pinned dependency for
+# the release workflow.
+git-cliff = "2.13.1"

--- a/readme.md
+++ b/readme.md
@@ -3,6 +3,7 @@
 This repository contains
 
 - the shared [renovate configuration](./default.json) for my projects
+  - released as a git tag and github release only. This way I can roughly track the changes in the github releases view
 - [oxfmt-config](packages/oxfmt-config) for the [oxfmt](https://oxc.rs/docs/guide/usage/formatter.html) code formatter,
   released as an [npm package](https://www.npmjs.com/package/@mikavilpas/oxfmt-config)
 


### PR DESCRIPTION
# ci: reimplement releases for the root package

This tracks changes made to the repository itself, and the renovate configuration (since it's at the root).

---

# Pull request stack

- 👉🏻 https://github.com/mikavilpas/mika-config/pull/628 👈🏻