### PR TITLE
chore: enable using oxfmt-config in dev without building it

### DIFF
--- a/packages/oxfmt-config/package.json
+++ b/packages/oxfmt-config/package.json
@@ -19,16 +19,19 @@
   ],
   "type": "module",
   "exports": {
-    ".": {
-      "types": "./dist/oxfmt.config.d.ts",
-      "import": "./dist/oxfmt.config.js"
-    }
+    ".": "./oxfmt.config.ts"
   },
   "publishConfig": {
+    "exports": {
+      ".": {
+        "types": "./dist/oxfmt.config.d.ts",
+        "import": "./dist/oxfmt.config.js"
+      }
+    },
     "access": "public"
   },
   "scripts": {
-    "build": "tsc && attw --pack",
+    "build": "rm -f ./*.tgz && tsc && pnpm pack && attw ./*.tgz; status=$?; rm -f ./*.tgz; exit $status",
     "prepack": "tsc"
   },
   "devDependencies": {


### PR DESCRIPTION
# chore: enable using oxfmt-config in dev without building it

---

# Pull request stack

- 👉🏻 https://github.com/mikavilpas/mika-config/pull/640 👈🏻