### PR TITLE
feat(oxlint-config)!: opt into only useful restriction rules

### DIFF
--- a/.changeset/opt-in-restriction-rules.md
+++ b/.changeset/opt-in-restriction-rules.md
@@ -1,0 +1,9 @@
+---
+"@mikavilpas/oxlint-config": major
+---
+
+Stop enabling oxlint's entire `restriction` category and instead opt into
+hand-picked rules from it.
+
+It was previously e.g. banning the use of async/await, which is not a
+good idea.

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -34,5 +34,4 @@ const config: KnipConfig = {
   },
 }
 
-// oxlint-disable-next-line import/no-default-export
 export default config

--- a/oxfmt.config.ts
+++ b/oxfmt.config.ts
@@ -1,7 +1,6 @@
 import packageConfig from "@mikavilpas/oxfmt-config"
 import { defineConfig } from "oxfmt"
 
-// oxlint-disable-next-line import/no-default-export
 export default defineConfig({
   ...packageConfig,
   ignorePatterns: ["**/CHANGELOG.md"],

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -1,7 +1,6 @@
 import mikaConfig from "@mikavilpas/oxlint-config"
 import { defineConfig } from "oxlint"
 
-// oxlint-disable-next-line import/no-default-export
 export default defineConfig({
   extends: [mikaConfig],
   jsPlugins: [

--- a/packages/oxfmt-config/oxfmt.config.ts
+++ b/packages/oxfmt-config/oxfmt.config.ts
@@ -12,5 +12,4 @@ const config: OxfmtConfig = defineConfig({
   sortPackageJson: {},
 })
 
-// oxlint-disable-next-line import/no-default-export
 export default config

--- a/packages/oxlint-config/configs/default.ts
+++ b/packages/oxlint-config/configs/default.ts
@@ -17,7 +17,6 @@ const config: OxlintConfig = defineConfig({
     correctness: "error",
     perf: "warn",
     suspicious: "warn",
-    restriction: "warn",
   },
   rules: {
     "prefer-const": "error",
@@ -126,6 +125,21 @@ const config: OxlintConfig = defineConfig({
       },
     ],
     "object-shorthand": "warn",
+
+    "no-param-reassign": "error",
+    "typescript/explicit-module-boundary-types": "error",
+    "no-eval": "error",
+    "unicorn/no-abusive-eslint-disable": "error",
+    "unicorn/prefer-module": "error",
+    "unicorn/no-anonymous-default-export": "error",
+    "no-unused-expressions": "error",
+    "oxc/no-const-enum": "error",
+    "typescript/promise-function-async": "error",
+    "unicorn/no-process-exit": "error",
+    // forbid dependency cycles and barrel files
+    "import/no-cycle": "error",
+    "oxc/no-barrel-file": "error",
+    "typescript/no-non-null-assertion": "warn",
   },
   overrides: [
     {
@@ -152,5 +166,4 @@ const config: OxlintConfig = defineConfig({
   ],
 })
 
-// oxlint-disable-next-line import/no-default-export
 export default config

--- a/syncpack.config.mjs
+++ b/syncpack.config.mjs
@@ -1,5 +1,4 @@
 /** @type {import("syncpack").RcFile} */
-// oxlint-disable-next-line import/no-default-export
 export default {
   strict: true,
   semverGroups: [


### PR DESCRIPTION
# feat(oxlint-config)!: opt into only useful restriction rules

It was previously e.g. banning the use of async/await, which is not a good idea.

---

# Pull request stack

- 👉🏻 https://github.com/mikavilpas/mika-config/pull/650 👈🏻