### PR TITLE
ci: fix not being able to tag a release touching github workflows

### DIFF
--- a/.changeset/moody-streets-taste.md
+++ b/.changeset/moody-streets-taste.md
@@ -1,0 +1,5 @@
+---
+"@mikavilpas/mika-config": patch
+---
+
+ci: fix not being able to tag a release touching github workflows

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,7 @@ jobs:
           private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
           permission-contents: write # push the Version PR branch, tags, and GitHub releases
           permission-pull-requests: write # open/update the "Version Packages" PR
+          permission-workflows: write # a new tag ref carries .github/workflows/*; a GitHub App can't create those tags without this
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0


### PR DESCRIPTION
# ci: fix not being able to tag a release touching github workflows

---

# Pull request stack

- 👉🏻 https://github.com/mikavilpas/mika-config/pull/654 👈🏻