### PR TITLE
fix(renovate-config): don't update peerDependencies automatically

### DIFF
--- a/.changeset/olive-hoops-clap.md
+++ b/.changeset/olive-hoops-clap.md
@@ -1,0 +1,6 @@
+---
+"@mikavilpas/renovate-config": patch
+---
+
+Leave peerDependencies alone, since each bump is a breaking change for consumers.
+The author must bump them manually when new versions are depended on.

--- a/packages/oxfmt-config/package.json
+++ b/packages/oxfmt-config/package.json
@@ -39,6 +39,6 @@
     "oxfmt": "catalog:"
   },
   "peerDependencies": {
-    "oxfmt": "^0.59.0 || ^0.60.0"
+    "oxfmt": "^0.59.0"
   }
 }

--- a/packages/renovate-config/README.md
+++ b/packages/renovate-config/README.md
@@ -44,6 +44,8 @@ configuration can be found in [default.test.ts](./default.test.ts).
 
 ### Package Rules
 
+- Leave peerDependencies alone, since each bump is a breaking change for consumers. The author must bump them manually
+  when new versions are depended on.
 - Automerge digest updates weekly
 
 ### Custom Managers

--- a/packages/renovate-config/default.json
+++ b/packages/renovate-config/default.json
@@ -5,6 +5,14 @@
   "commitBodyTable": true,
   "packageRules": [
     {
+      "description": [
+        "Leave peerDependencies alone, since each bump is a breaking change for consumers.",
+        "The author must bump them manually when new versions are depended on."
+      ],
+      "matchDepTypes": ["peerDependencies"],
+      "enabled": false
+    },
+    {
       "description": ["Automerge digest updates weekly"],
       "matchUpdateTypes": ["digest"],
       "automerge": true,


### PR DESCRIPTION
# fix(renovate-config): don't update peerDependencies automatically

Leave peerDependencies alone, since each bump is a breaking change for consumers. The author must bump them manually when new versions are depended on.

---

# Pull request stack

- 👉🏻 https://github.com/mikavilpas/mika-config/pull/685 👈🏻