### PR TITLE
ci: fix release tag pattern not matching actual release tags

### DIFF
--- a/.github/workflows/document-release.yml
+++ b/.github/workflows/document-release.yml
@@ -9,7 +9,7 @@ name: Document release
 on:
   push:
     tags:
-      - "v[0-9]*"
+      - "v[0-9]+.[0-9]+.[0-9]+"
 
 permissions:
   contents: read


### PR DESCRIPTION
# ci: fix release tag pattern not matching actual release tags

The `document-release.yml` workflow never ran.

---

# Pull request stack

- 👉🏻 https://github.com/mikavilpas/mika-config/pull/686 👈🏻