### PR TITLE
fix: require ^ or >= ranges for peerDependencies

### DIFF
--- a/.changeset/olive-pianos-repeat.md
+++ b/.changeset/olive-pianos-repeat.md
@@ -1,0 +1,8 @@
+---
+"@mikavilpas/syncpack-config": patch
+"@mikavilpas/oxfmt-config": patch
+"@mikavilpas/oxlint-config": patch
+"@mikavilpas/knip-config": patch
+---
+
+Use `peerDependencies` like `>=` or `^` to avoid unnecessary updates. Widen the version ranges so that consumers can deduplicate more versions.

--- a/packages/knip-config/package.json
+++ b/packages/knip-config/package.json
@@ -39,6 +39,6 @@
     "knip": "catalog:"
   },
   "peerDependencies": {
-    "knip": "^6.27.0"
+    "knip": ">=6.27.0"
   }
 }

--- a/packages/oxfmt-config/package.json
+++ b/packages/oxfmt-config/package.json
@@ -39,6 +39,6 @@
     "oxfmt": "catalog:"
   },
   "peerDependencies": {
-    "oxfmt": "^0.59.0"
+    "oxfmt": ">=0.59.0"
   }
 }

--- a/packages/oxlint-config/package.json
+++ b/packages/oxlint-config/package.json
@@ -40,7 +40,7 @@
     "oxlint-tsgolint": "catalog:"
   },
   "peerDependencies": {
-    "oxlint": "^1.74.0",
-    "oxlint-tsgolint": "^7.0.2001"
+    "oxlint": ">=1.74.0",
+    "oxlint-tsgolint": ">=7.0.2001"
   }
 }

--- a/packages/syncpack-config/configs/syncpack-default.ts
+++ b/packages/syncpack-config/configs/syncpack-default.ts
@@ -4,16 +4,20 @@ const config: RcFile = {
   strict: true,
   semverGroups: [
     {
-      // this allows consumers to use a matching version and save disk space
-      // and installation time
-      label: "peerDependencies use caret ranges",
+      // - Don't allow "1.2.3"
+      // - Allow "^1.2.3", ">=1.2.3" or "^13 || ^14".
+      label: "peerDependencies must not be exact pins",
       dependencyTypes: ["peer"],
+      specifierTypes: ["exact"],
       range: "^",
     },
   ],
   versionGroups: [
     {
-      label: "Peer deps must look like ^1.2.3 (no exact pins)",
+      // Keeps peer ranges mutually compatible, and rejects specifiers syncpack
+      // cannot parse. Syncpack seems to be picky here - ">= 1.2.3" reports
+      // SameRangeMismatch, ">=1.2.3" is fine (no space).
+      label: "Peer deps must be parseable, mutually compatible ranges",
       dependencyTypes: ["peer"],
       policy: "sameRange",
     },

--- a/packages/syncpack-config/package.json
+++ b/packages/syncpack-config/package.json
@@ -38,6 +38,6 @@
     "syncpack": "catalog:"
   },
   "peerDependencies": {
-    "syncpack": "^15.3.2"
+    "syncpack": ">=15.3.2"
   }
 }


### PR DESCRIPTION
# fix: require ^ or >= ranges for peerDependencies

**Issue:**

For my packages, I want to publish compatible peer ranges so that consumers can deduplicate dependencies and save disk space.

syncpack seemed to have issues reliably detecting the ranges. In any case it's low signal, high noise.

**Solution:**

Make syncpack disallow exact pins in peer ranges, but don't rewrite existing ranges to a caret range.

---

# Pull request stack

- 👉🏻 https://github.com/mikavilpas/mika-config/pull/699 👈🏻